### PR TITLE
Route for downloading slide image

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -150,3 +150,11 @@ def singleThumb(filepath):
 @app.route("/data/many/<filepathlist>", methods=['GET'])
 def multiSlide(filepathlist):
     return json.dumps(dev_utils.getMetadataList(json.loads(filepathlist), app.config['UPLOAD_FOLDER']))
+
+@app.route("/getSlide/<image_name>")
+def getSlide(image_name):
+    if(os.path.isfile("/images/"+image_name)):
+        return flask.send_from_directory(app.config["UPLOAD_FOLDER"], filename=image_name, as_attachment=True)
+    else:
+        return flask.Response(json.dumps({"error": "File doesnot exist"}), status=400)  
+            

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -156,5 +156,5 @@ def getSlide(image_name):
     if(os.path.isfile("/images/"+image_name)):
         return flask.send_from_directory(app.config["UPLOAD_FOLDER"], filename=image_name, as_attachment=True)
     else:
-        return flask.Response(json.dumps({"error": "File doesnot exist"}), status=400)  
+        return flask.Response(json.dumps({"error": "File does not exist"}), status=404)  
             


### PR DESCRIPTION
A new route 
`/getSlide/<image_name>` is created which returns the image file.