### PR TITLE
'Upload from URL' routes

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -182,10 +182,10 @@ def continue_urlfile(token):
             try:
                 url = urllib.parse.unquote(url)
                 urllib.request.urlretrieve(url, tmppath)
+                uploadStatus.uploadedStatus = "True"
+                return flask.Response(json.dumps({"status": "OK Uploaded"}), status=200)
             except:
-                return flask.Response(json.dumps({"status": "URL invalid"}), status=400)        
-            uploadStatus.uploadedStatus = "True"
-            return flask.Response(json.dumps({"status": "OK Uploaded"}), status=200)
+                return flask.Response(json.dumps({"status": "URL invalid"}), status=400)
     else:
         return flask.Response(json.dumps({"error": "Token Not Recognised"}), status=400)
 

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -12,6 +12,7 @@ import flask_cors
 import openslide
 from werkzeug.utils import secure_filename
 import dev_utils
+import requests
 
 try:
     from io import BytesIO
@@ -159,15 +160,9 @@ def getSlide(image_name):
         return flask.Response(json.dumps({"error": "File does not exist"}), status=404)  
 
 
-
-class upload():
-    uploadedStatus = "False"
-uploadStatus = upload();
-
 # using the token from the start url upload endpoint
 @app.route('/urlupload/continue/<token>', methods=['POST'])
 def continue_urlfile(token):
-    uploadStatus.uploadedStatus = "False"
     token = secure_filename(token)
     tmppath = os.path.join(app.config['TEMP_FOLDER'], token)
     if os.path.isfile(tmppath):
@@ -178,21 +173,26 @@ def continue_urlfile(token):
             return flask.Response(json.dumps({"error": "File url not present in body"}), status=400)
         else:
             url = body['url']
-            uploadStatus.uploadedStatus = "False"
             try:
                 url = urllib.parse.unquote(url)
                 urllib.request.urlretrieve(url, tmppath)
-                uploadStatus.uploadedStatus = "True"
                 return flask.Response(json.dumps({"status": "OK Uploaded"}), status=200)
             except:
                 return flask.Response(json.dumps({"status": "URL invalid"}), status=400)
     else:
         return flask.Response(json.dumps({"error": "Token Not Recognised"}), status=400)
 
-
+# Route to check if the URL file has completely uploaded to the server 
+# Query Params: 'url', 'token'
 @app.route('/urlupload/check', methods=['GET'])
 def urlUploadStatus():
-    if(uploadStatus.uploadedStatus=="True"):
-        uploadStatus.uploadedStatus=="False"
+    url = flask.request.args.get('url')
+    url = urllib.parse.unquote(url)
+    token = flask.request.args.get('token')
+    info = requests.head(url)
+    urlFileSize = int(info.headers['Content-Length'])
+    fileSize = os.path.getsize(app.config['TEMP_FOLDER']+'/'+token)
+    if(fileSize >= urlFileSize):
         return flask.Response(json.dumps({"uploaded": "True"}), status=200)
-    return flask.Response(json.dumps({"uploaded": "False"}), status=200)
+    else:
+        return flask.Response(json.dumps({"uploaded": "False"}), status=200)

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -34,8 +34,10 @@ def getMetadata(filename, upload_folder):
         "openslide.level[0].width", None)
     metadata['vendor'] = slideData.get(openslide.PROPERTY_NAME_VENDOR, None)
     metadata['level_count'] = int(slideData.get('level_count', 1))
-    metadata['objective'] = float(slideData.get("aperio.AppMag", -1.0))
+    metadata['objective'] = float(slideData.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER, 0) or
+                                  slideData.get("aperio.AppMag", -1.0))
     metadata['md5sum'] = file_md5(filepath)
+    metadata['comment'] = slideData.get(openslide.PROPERTY_NAME_COMMENT
     metadata['study'] = ""
     metadata['specimen'] = ""
     return metadata


### PR DESCRIPTION
Two new routes have been added.
One for uploading image file from the given URL.
The other for checking that whether the image upload has been completed or not (is useful for large image files or less bandwidth connection)

This is used with [caMicroscope #353](https://github.com/camicroscope/caMicroscope/pull/353)