### PR TITLE
Support for large dataset files and tiff images [Development Workbench]

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -280,38 +280,42 @@ def getLabelsZips():
 @app.route('/workbench/getCustomData', methods=['POST'])
 def getCustomData():
     data = flask.request.get_json()
-    fileName = data['fileNames'][0]
-    userFolder = ''.join(random.choice(
-    string.ascii_uppercase + string.digits) for _ in range(20))
+    fileName = data['fileName']
+    userFolder = data['userFolder']
     if not os.path.isdir(app.config['DATASET_FOLDER']+userFolder):
         os.makedirs(app.config['DATASET_FOLDER']+userFolder)
     path = os.path.join(app.config['DATASET_FOLDER']+userFolder+'/', fileName)
-    fileData = base64.b64decode(data['files'][0])
+    fileData = base64.b64decode(data['file'])
+    offset = data['offset']
     file = open(path, "ab")
-    file.seek(0)
+    file.seek(int(offset))
     file.write(fileData)
     file.close()
-    if(zipfile.is_zipfile(path) == False):
-        deleteDataset(userFolder)
-        return flask.Response(json.dumps({'error': 'Not a valid zip file/files'}), status=400)
-    file = zipfile.ZipFile(path, 'r')
-    # app.logger.info(file.namelist())
-    contents = file.namelist()
-    labelsData = {'labels': [], 'counts': [], 'userFolder': userFolder}
-    for item in contents:
-        if '/' not in item:
-            return flask.Response(json.dumps({'error': 'zip should contain only folders!'}), status=400)
-        if item.endswith('/') == False and item.endswith('.jpg') == False and item.endswith('.png') == False:
-            return flask.Response(json.dumps({'error': 'Dataset should have only png/jpg files!'}), status=400)
-        if item.split('/')[0] not in labelsData['labels']:
-            labelsData['labels'].append(item.split('/')[0])
-    for label in labelsData['labels']:
-        count = -1
+    final = data['final']
+    if(final == 'true'):
+        if(zipfile.is_zipfile(path) == False):
+            deleteDataset(userFolder)
+            return flask.Response(json.dumps({'error': 'Not a valid zip file/files'}), status=400)
+        file = zipfile.ZipFile(path, 'r')
+        # app.logger.info(file.namelist())
+        contents = file.namelist()
+        labelsData = {'labels': [], 'counts': [], 'userFolder': userFolder}
         for item in contents:
-            if item.startswith(label+'/'):
-                count+=1
-        labelsData['counts'].append(count)
-    return flask.Response(json.dumps(labelsData), status=200)
+            if '/' not in item:
+                return flask.Response(json.dumps({'error': 'zip should contain only folders!'}), status=400)
+            if item.endswith('/') == False and item.endswith('.jpg') == False and item.endswith('.jpeg') == False and item.endswith('.png') == False and item.endswith('.tif') == False and item.endswith('.tiff') == False:
+                return flask.Response(json.dumps({'error': 'Dataset should have only png/jpg files!'}), status=400)
+            if item.split('/')[0] not in labelsData['labels']:
+                labelsData['labels'].append(item.split('/')[0])
+        for label in labelsData['labels']:
+            count = -1
+            for item in contents:
+                if item.startswith(label+'/'):
+                    count+=1
+            labelsData['counts'].append(count)
+        return flask.Response(json.dumps(labelsData), status=200)
+    else:
+        return flask.Response(json.dumps({'status' : 'pending'}), status=200)
 
 
 # Route to organise the extracted zip file data according to user sent customized labels and create a spritesheet

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -302,9 +302,11 @@ def getCustomData():
         labelsData = {'labels': [], 'counts': [], 'userFolder': userFolder}
         for item in contents:
             if '/' not in item:
+                deleteDataset(userFolder)
                 return flask.Response(json.dumps({'error': 'zip should contain only folders!'}), status=400)
             if item.endswith('/') == False and item.endswith('.jpg') == False and item.endswith('.jpeg') == False and item.endswith('.png') == False and item.endswith('.tif') == False and item.endswith('.tiff') == False:
-                return flask.Response(json.dumps({'error': 'Dataset should have only png/jpg files!'}), status=400)
+                deleteDataset(userFolder)
+                return flask.Response(json.dumps({'error': 'Dataset zip should have only png/jpg/tif files!'}), status=400)
             if item.split('/')[0] not in labelsData['labels']:
                 labelsData['labels'].append(item.split('/')[0])
         for label in labelsData['labels']:

--- a/spritemaker.py
+++ b/spritemaker.py
@@ -19,15 +19,12 @@ def createSpritesheet(datasetPath, labelsNames, width, height):
     y_offset = 0
     imageCount = 0
     imageFiles = []
-    for image_file in Path(TRAINING_PATH).glob("**/*.jpg"):
-        imageCount += 1
-        imageFiles.append(image_file)
-    for image_file in Path(TRAINING_PATH).glob("**/*.png"):
-        imageCount += 1
-        imageFiles.append(image_file)
-    for image_file in Path(TRAINING_PATH).glob("**/*.jpeg"):
-        imageCount += 1
-        imageFiles.append(image_file)
+
+    allowed_extentions = ['jpg', 'png', 'jpeg', 'tif', 'tiff']
+    for ext in allowed_extentions:
+        for image_file in Path(TRAINING_PATH).glob("**/*." + ext):
+            imageCount += 1
+            imageFiles.append(image_file)
 
     print(imageCount, file=sys.stderr)
     new_im = Image.new('RGB', (width*height, imageCount))


### PR DESCRIPTION
Works with [caMicroscope #421](https://github.com/camicroscope/caMicroscope/pull/421)
## Description
- Support for tif images is added in `spritemaker`
- Larger files can be handled now using base64 file chunks sent from caMircroscope

## How Has This Been Tested?
Briefly tested on Firefox (79.0), Chrome (84.0), Brave (1.10.x) on Windows 10 and Linux-LTS (arch - deepin)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
