### PR TITLE
Download file from Google Drive to Server [Feature]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN pip3 install -r requirements.txt
 
 
 EXPOSE 4000
+EXPOSE 4001
 
 #debug/dev only
 # ENV FLASK_APP SlideServer.py

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -541,7 +541,7 @@ class getFileFromGdrive(Thread):
         self.params, self.userId, self.fileId , self.token = params, userId, fileId, token
 
     def run(self):
-        if(self.auth_url != None):
+        if(self.params["auth_url"] != None):
             self.params["creds"] = afterUrlAuth(self.params["local_server"], self.params["flow"], self.params["wsgi_app"], self.userId)
         call = callApi(self.params["creds"], self.fileId, self.token)
         app.logger.info(call)

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -235,52 +235,6 @@ def urlUploadStatus():
     else:
         return flask.Response(json.dumps({"uploaded": "False"}), status=200)
 
-class getFile(Thread):
-    def __init__(self, auth_url, local_server, wsgi_app, flow, creds, userId, fileId, token):
-        Thread.__init__(self)
-        self.auth_url, self.local_server, self.wsgi_app, self.flow, self.creds, self.userId, self.fileId , self.token = auth_url, local_server, wsgi_app, flow, creds, userId, fileId, token
-
-    def run(self):
-        if(self.auth_url != None):
-            self.creds = afterUrlAuth(self.local_server, self.flow, self.wsgi_app, self.userId)
-        call = callApi(self.creds, self.fileId, self.token)
-        app.logger.info(call)
-
-# Route to return google-picker API credentials
-@app.route('/googleDriveUpload/getFile', methods=['POST'])
-def gDriveGetFile():
-    body = flask.request.get_json()
-    if not body:
-        return flask.Response(json.dumps({"error": "Missing JSON body"}), status=400)
-
-    token = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
-    token = secure_filename(token)
-    tmppath = os.path.join("/images/uploading/", token)
-    # regenerate if we happen to collide
-    while os.path.isfile(tmppath):
-        token = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
-        token = secure_filename(token)
-        tmppath = os.path.join("/images/uploading/", token)
-
-    creds = None
-    try:
-        auth_url, local_server, wsgi_app, flow, creds = start(body['userId'])
-    except:
-        return flask.Response(json.dumps({'error': str(sys.exc_info()[0])}), status=400)
-    thread_a = getFile(auth_url, local_server, wsgi_app, flow, creds, body['userId'], body['fileId'], token)
-    thread_a.start()
-    return flask.Response(json.dumps({"authURL": auth_url, "token": token}), status=200)
-
-@app.route('/googleDriveUpload/checkStatus', methods=['POST'])
-def checkDownloadStatus():
-    body = flask.request.get_json()
-    if not body:
-        return flask.Response(json.dumps({"error": "Missing JSON body"}), status=400)
-    token = body['token']
-    path = app.config['TEMP_FOLDER']+'/'+token
-    if os.path.isfile(path):
-        return flask.Response(json.dumps({"downloadDone": True}), status=200)
-    return flask.Response(json.dumps({"downloadDone": False}), status=200)
 
 
 # Workbench Dataset Creation help-routes
@@ -577,4 +531,54 @@ def roiextract(file_name):
 
     return flask.send_from_directory(app.config["ROI_FOLDER"],filename=file_name, as_attachment=True, cache_timeout=0 )
 
+
+# Google Drive API (OAuth and File Download) Routes
+
+# A new Thread to call the Gdrive API after an Auth Response is returned to the user.
+class getFileFromGdrive(Thread):
+    def __init__(self, params, userId, fileId, token):
+        Thread.__init__(self)
+        self.params, self.userId, self.fileId , self.token = params, userId, fileId, token
+
+    def run(self):
+        if(self.auth_url != None):
+            self.params["creds"] = afterUrlAuth(self.params["local_server"], self.params["flow"], self.params["wsgi_app"], self.userId)
+        call = callApi(self.params["creds"], self.fileId, self.token)
+        app.logger.info(call)
+
+# Route to start the OAuth Server(to listen if user is Authenticated) and start the file Download after Authentication
+@app.route('/googleDriveUpload/getFile', methods=['POST'])
+def gDriveGetFile():
+    body = flask.request.get_json()
+    if not body:
+        return flask.Response(json.dumps({"error": "Missing JSON body"}), status=400)
+
+    token = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+    token = secure_filename(token)
+    tmppath = os.path.join("/images/uploading/", token)
+    # regenerate if we happen to collide
+    while os.path.isfile(tmppath):
+        token = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        token = secure_filename(token)
+        tmppath = os.path.join("/images/uploading/", token)
+
+    try:
+        params = start(body['userId'])
+    except:
+        return flask.Response(json.dumps({'error': str(sys.exc_info()[0])}), status=400)
+    thread_a = getFileFromGdrive(params, body['userId'], body['fileId'], token)
+    thread_a.start()
+    return flask.Response(json.dumps({"authURL": params["auth_url"], "token": token}), status=200)
+
+# To check if a particular file is downloaded from Gdrive
+@app.route('/googleDriveUpload/checkStatus', methods=['POST'])
+def checkDownloadStatus():
+    body = flask.request.get_json()
+    if not body:
+        return flask.Response(json.dumps({"error": "Missing JSON body"}), status=400)
+    token = body['token']
+    path = app.config['TEMP_FOLDER']+'/'+token
+    if os.path.isfile(path):
+        return flask.Response(json.dumps({"downloadDone": True}), status=200)
+    return flask.Response(json.dumps({"downloadDone": False}), status=200)
 

--- a/gDriveDownload.py
+++ b/gDriveDownload.py
@@ -1,16 +1,27 @@
 from __future__ import print_function
 import pickle
-import os.path
 import wsgiref.simple_server
 import wsgiref.util
+from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow, _WSGIRequestHandler, _RedirectWSGIApp
+from google_auth_oauthlib.flow import (
+    InstalledAppFlow,
+    _WSGIRequestHandler,
+    _RedirectWSGIApp,
+)
 from google.auth.transport.requests import Request
 import sys
 import os
+import io
+import shutil
+import random
+import string
+from werkzeug.utils import secure_filename
 
-# If modifying these scopes, delete the file token.pickle.
-SCOPES = ['https://www.googleapis.com/auth/drive.readonly']
+
+# If modifying these scopes, delete the file <userID>.pickle files.
+SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
 
 def run_local_server(
     self=InstalledAppFlow,
@@ -18,39 +29,45 @@ def run_local_server(
     port=4001,
     authorization_prompt_message=InstalledAppFlow._DEFAULT_AUTH_PROMPT_MESSAGE,
     success_message=InstalledAppFlow._DEFAULT_WEB_SUCCESS_MESSAGE,
+    userId=None,
 ):
     wsgi_app = _RedirectWSGIApp(success_message)
     local_server = wsgiref.simple_server.make_server(
         host, port, wsgi_app, handler_class=_WSGIRequestHandler
     )
 
-    self.redirect_uri = "http://localhost:4010/googleAuth/"
+    self.redirect_uri = "http://localhost:4010/googleAuth/" + userId
     auth_url, _ = self.authorization_url()
-
 
     print(authorization_prompt_message.format(url=auth_url))
 
     return auth_url, local_server, wsgi_app, None
 
-def afterUrlAuth(local_server, flow, wsgi_app):
+
+def afterUrlAuth(local_server, flow, wsgi_app, userId):
     local_server.handle_request()
 
     # Note: using https here because oauthlib is very picky that
     # OAuth 2.0 should only occur over https.
     authorization_response = wsgi_app.last_request_uri.replace("http", "https")
     flow.fetch_token(authorization_response=authorization_response)
-            # Save the credentials for the next run
-    with open('token.pickle', 'wb') as token:
+    # Save the credentials for the next run
+    with open(
+        "/cloud-upload-apis/tokens/" + userId + ".pickle", "wb"
+    ) as token:
         pickle.dump(flow.credentials, token)
     return flow.credentials
 
-def startDownload():
+
+def start(userId):
     creds = None
     # The file token.pickle stores the user's access and refresh tokens, and is
     # created automatically when the authorization flow completes for the first
     # time.
-    if os.path.exists('token.pickle'):
-        with open('token.pickle', 'rb') as token:
+    if os.path.exists("/cloud-upload-apis/tokens/" + userId + ".pickle"):
+        with open(
+            "/cloud-upload-apis/tokens/" + userId + ".pickle", "rb"
+        ) as token:
             creds = pickle.load(token)
         return None, None, None, None, creds
     # If there are no (valid) credentials available, let the user log in.
@@ -59,30 +76,60 @@ def startDownload():
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                './credentials/google-drive.json', SCOPES)
-            auth_url, local_server, wsgi_app, creds = run_local_server(self=flow)
+                "/cloud-upload-apis/credentials/google-drive.json", SCOPES
+            )
+            auth_url, local_server, wsgi_app, creds = run_local_server(
+                self=flow, userId=userId
+            )
             return auth_url, local_server, wsgi_app, flow, creds
             # creds = afterUrlAuth(local_server, flow, wsgi_app)
-            
 
 
-def callApi(creds):
-    service = build('drive', 'v3', credentials=creds)
+def callApi(creds, fileId):
+
+    # fileId = "1HXJqXupb5L8YhCN6KV45_FUHm4K3Hp9r"
+    # fileId = "1NyErLXDZgv1s00-5hnyBqCd5t80SHV3g"
+
+    service = build("drive", "v3", credentials=creds)
 
     # Call the Drive v3 API
-    results = service.files().list(
-        pageSize=10, fields="nextPageToken, files(id, name)").execute()
-    items = results.get('files', [])
+    request = service.files().get_media(fileId=fileId)
+    fileName = service.files().get(fileId=fileId).execute()["name"]
 
-    if not items:
-        print('No files found.')
-        return items
-    else:
-        print('Files:')
-        return items
-        # for item in items:
-        #     print(u'{0} ({1})'.format(item['name'], item['id']))
+    token = "".join(
+        random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+    )
+    token = secure_filename(token)
+    tmppath = os.path.join("/images/uploading/", token)
+    # regenerate if we happen to collide
+    while os.path.isfile(tmppath):
+        token = "".join(
+            random.choice(string.ascii_uppercase + string.digits) for _ in range(10)
+        )
+        token = secure_filename(token)
+        tmppath = os.path.join("/images/uploading/", token)
 
+    fh = io.BytesIO()
+
+    # Initialise a downloader object to download the file
+    downloader = MediaIoBaseDownload(fh, request)
+    done = False
+
+    try:
+        # Download the data in chunks
+        while not done:
+            status, done = downloader.next_chunk()
+        fh.seek(0)
+        # Write the received data to the file
+        with open("/images/uploading/" + token, "wb") as f:
+            shutil.copyfileobj(fh, f)
+
+        print("File Downloaded")
+        # Return True if file Downloaded successfully
+        return {"status": True, "fileName": fileName, "token": token}
+    except:
+        # Return False if something went wrong
+        print("Something went wrong.")
 
 
 # startDownload()

--- a/gDriveDownload.py
+++ b/gDriveDownload.py
@@ -1,0 +1,88 @@
+from __future__ import print_function
+import pickle
+import os.path
+import wsgiref.simple_server
+import wsgiref.util
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow, _WSGIRequestHandler, _RedirectWSGIApp
+from google.auth.transport.requests import Request
+import sys
+import os
+
+# If modifying these scopes, delete the file token.pickle.
+SCOPES = ['https://www.googleapis.com/auth/drive.readonly']
+
+def run_local_server(
+    self=InstalledAppFlow,
+    host="0.0.0.0",
+    port=4001,
+    authorization_prompt_message=InstalledAppFlow._DEFAULT_AUTH_PROMPT_MESSAGE,
+    success_message=InstalledAppFlow._DEFAULT_WEB_SUCCESS_MESSAGE,
+):
+    wsgi_app = _RedirectWSGIApp(success_message)
+    local_server = wsgiref.simple_server.make_server(
+        host, port, wsgi_app, handler_class=_WSGIRequestHandler
+    )
+
+    self.redirect_uri = "http://localhost:4010/googleAuth/"
+    auth_url, _ = self.authorization_url()
+
+
+    print(authorization_prompt_message.format(url=auth_url))
+
+    return auth_url, local_server, wsgi_app, None
+
+def afterUrlAuth(local_server, flow, wsgi_app):
+    local_server.handle_request()
+
+    # Note: using https here because oauthlib is very picky that
+    # OAuth 2.0 should only occur over https.
+    authorization_response = wsgi_app.last_request_uri.replace("http", "https")
+    flow.fetch_token(authorization_response=authorization_response)
+            # Save the credentials for the next run
+    with open('token.pickle', 'wb') as token:
+        pickle.dump(flow.credentials, token)
+    return flow.credentials
+
+def startDownload():
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+        return None, None, None, None, creds
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                './credentials/google-drive.json', SCOPES)
+            auth_url, local_server, wsgi_app, creds = run_local_server(self=flow)
+            return auth_url, local_server, wsgi_app, flow, creds
+            # creds = afterUrlAuth(local_server, flow, wsgi_app)
+            
+
+
+def callApi(creds):
+    service = build('drive', 'v3', credentials=creds)
+
+    # Call the Drive v3 API
+    results = service.files().list(
+        pageSize=10, fields="nextPageToken, files(id, name)").execute()
+    items = results.get('files', [])
+
+    if not items:
+        print('No files found.')
+        return items
+    else:
+        print('Files:')
+        return items
+        # for item in items:
+        #     print(u'{0} ({1})'.format(item['name'], item['id']))
+
+
+
+# startDownload()

--- a/gDriveDownload.py
+++ b/gDriveDownload.py
@@ -61,7 +61,14 @@ def start(userId):
             "/cloud-upload-apis/tokens/googleDrive" + userId + ".pickle", "rb"
         ) as token:
             creds = pickle.load(token)
-        return None, None, None, None, creds
+        return {
+            "auth_url": None,
+            "local_server": None,
+            "wsgi_app": None,
+            "flow": None,
+            "creds": creds,
+        }
+
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ flask-cors
 requests
 numpy
 Pillow
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib


### PR DESCRIPTION
This works with [caMicroscope #467](https://github.com/camicroscope/caMicroscope/pull/467) and [Distro #154](https://github.com/camicroscope/Distro/pull/154)

## Description
- Google Drive API is used to download the file from a provided fileID.
-  The API keys for the same are fetched from `/cloud-upload-apis/credentials/google-drive.json` file in **Distro**.
- Authentication is done by creating a new server in runtime at :4001 in docker.
- The :4001 is exposed and a dynamic user specific redirect URL route is created at `/googleAuth/<userID>` to listen for the authentication completion.
- The file is downloaded to the `/images/uploading` folder like any normal slide and normal procedure will follow afterwards.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
