### PR TITLE
use another user for slideloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,11 @@ EXPOSE 4001
 # ENV FLASK_APP SlideServer.py
 # CMD python -m flask run --host=0.0.0.0 --port=4000
 
+# non-root user
+RUN chgrp -R 0 /var && \
+    chmod -R g+rwX /var
+
+USER 1001
+
 #prod only
 CMD gunicorn -w 4 -b 0.0.0.0:4000 SlideServer:app --timeout 400


### PR DESCRIPTION
In the same vein as @tkurc 's prism patches. I assume this one was avoided as it's not used in prism normally.