### PR TITLE
To create an Uploading directory if it doesn't exist

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -35,6 +35,10 @@ flask_cors.CORS(app)
 # dataset storage location for the workbench tasks 
 app.config['DATASET_FOLDER'] = "/images/dataset/"
 
+#creating a uploading folder if it doesn't exist
+if not os.path.exists('/images/uploading/'):
+    os.mkdir('/images/uploading')
+
 # where to put and get slides
 app.config['UPLOAD_FOLDER'] = "/images/"
 app.config['TEMP_FOLDER'] = "/images/uploading/"


### PR DESCRIPTION
It just checks if the folder path ```/images/uploading/``` exists and creates a directory only if it doesn't.

Should fix issue #37.