### PR TITLE
Update Debian apt repo to "Buster"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-stretch
+FROM python:3-buster
 
 WORKDIR /var/www
 RUN apt-get update


### PR DESCRIPTION
Stretch was archived according to an announcement in 2023: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html I found this while running Docker-compose, when apt looked for packages at stretch but was unable to find them because they were moved to the archives so a Stackoverflow post (https://stackoverflow.com/a/76094521) suggested editing apt links to the archive repo or to update apt to use buster or a newer release. (The Buster repo is expected to move to archives in 2025)

## Testing

I think the important point is that updating the apt repo pointer does not change libraries but if it can cause failures, it'll fail at the build stage

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
