### PR TITLE
Flask API typo

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -216,7 +216,7 @@ def multiSlide(filepathlist):
 @app.route("/getSlide/<image_name>")
 def getSlide(image_name):
     if(os.path.isfile("/images/"+image_name)):
-        return flask.send_from_directory(app.config["UPLOAD_FOLDER"], filename=image_name, as_attachment=True)
+        return flask.send_from_directory(app.config["UPLOAD_FOLDER"], image_name, as_attachment=True)
     else:
         return flask.Response(json.dumps({"error": "File does not exist"}), status=404)
 
@@ -551,7 +551,7 @@ def roiExtract():
 @app.route('/roiextract/<file_name>')
 def roiextract(file_name):
 
-    return flask.send_from_directory(app.config["ROI_FOLDER"],filename=file_name, as_attachment=True, cache_timeout=0 )
+    return flask.send_from_directory(app.config["ROI_FOLDER"], file_name, as_attachment=True, cache_timeout=0 )
 
 
 # Google Drive API (OAuth and File Download) Routes


### PR DESCRIPTION
When click click to download an image, I receive a 265-byte text file instead, which turned out to be:

```
<!doctype html>
<html lang=en>
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>
```

So I changed these to unnamed parameters as described here: https://tedboy.github.io/flask/generated/flask.send_from_directory.html

Tested, downloading does work now