### PR TITLE
Handle uploading filenames with special characters

### DIFF
--- a/SlideServer.py
+++ b/SlideServer.py
@@ -99,7 +99,11 @@ def start_upload():
         tmppath = os.path.join(app.config['TEMP_FOLDER'], token)
     f = open(tmppath, 'a')
     f.close()
-    return flask.Response(json.dumps({"upload_token": token}), status=200)
+    res_body = {"upload_token": token}
+    body = flask.request.get_json()
+    if body and body.get('filename'):
+        res_body['filename'] = secure_filename(body['filename'])
+    return flask.Response(json.dumps(res_body), status=200)
 
 
 # using the token from the start upload endpoint, post data given offset.
@@ -145,7 +149,7 @@ def finish_upload(token):
             else:
                 return flask.Response(json.dumps({"error": "Token Not Recognised"}), status=400)
         else:
-            return flask.Response(json.dumps({"error": "File with name '" + filename + "' already exists"}), status=400)
+            return flask.Response(json.dumps({"error": "File with name '" + filename + "' already exists", "filepath": filepath}), status=400)
 
     else:
         return flask.Response(json.dumps({"error": "Invalid filename"}), status=400)


### PR DESCRIPTION
Backend part of #640

- A user can input `#(.svs` and this would be sanitized to `.svs` which is an invisible system file so sanitized again to `svs` which turns out to not have an extension thus not usable. The patch sanitizes this to `noname.svs`
- Send the sanitized filename with "/upload/start", which already received the original filename. This allows user to understand that special chared filenames are not allowed early
- Don't allow `a.sVs` etc which can't be viewed already. Don't allow for new files only
- `File with name '" + filename + "' already exists` should also return filename