### PR TITLE
Build libvips ALSO without openslide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,63 @@ WORKDIR /var/www
 RUN apt-get update
 RUN apt-get -q update --fix-missing
 RUN apt-get -q install -y openslide-tools python3-openslide vim openssl
-RUN apt-get -q install -y libvips libvips-dev
+
+# Tony has a future use case where we may adapt caMic to GIS visualization
+# install libvips-dev for pyvips. No need for libvips.
+RUN apt-get -q install -y libvips-dev
+
+# But, build libvips instead of using libvips-dev from apt
+# Build without OpenSlide to open images with rather ImageMagick to handle
+# images without pyramids. Otherwise opens e.g. DICOM with OpenSlide so conversion
+# of files OpenSlide cannot open does not help at all.
+# So, we'll have two copies on openslide on the system.
+# By changing LD_LIBRARY_PATH before we launch python
+# we can choose which openslide to run
+# TODO: replace libjpeg-dev with libjpeg-turbo8-dev when current apt repo has it; for performance
+RUN apt-get -q install -y meson libjpeg-dev libexif-dev libgsf-1-dev libtiff-dev libfftw3-dev liblcms2-dev libpng-dev libmagickcore-dev libmagickwand-dev liborc-0.4-dev libopenjp2-7 libgirepository1.0-dev
+WORKDIR /root/src
+RUN git clone https://github.com/libvips/libvips.git --depth=1 --branch=8.14
+RUN mkdir /root/src/libvips/build
+WORKDIR /root/src/libvips
+RUN mkdir /usr/local/vips-no-openslide/
+# normally --prefix=/usr/local/ --libdir=lib build
+RUN meson setup -Dopenslide=disabled --buildtype=release --prefix=/usr/local/vips-no-openslide/ --libdir=lib build
+RUN meson compile -C build
+RUN meson test -C build
+RUN meson install -C build
 
 RUN pip install pyvips
 RUN pip install flask
 RUN pip install gunicorn
 RUN pip install greenlet
 RUN pip install gunicorn[eventlet]
+
+# verify pyvips can call libvips
+RUN python3 -c "import pyvips"
+
+# verify that the apt libvips has openslide
+ADD test_imgs/CMU-1-Small-Region.svs .
+RUN python3 -c "import pyvips; pyvips.Image.openslideload(('CMU-1-Small-Region.svs'))"
+
+# back up previous ld_library_path
+ENV LD_LIBRARY_PATH_ORIG="${LD_LIBRARY_PATH}"
+
+# now, prioritize openslideless libvips
+# the path shown in output lines of "meson install" where .so.42 are installed
+# normally /usr/local/lib/:
+ENV LD_LIBRARY_PATH="/usr/local/vips-no-openslide/lib/:${LD_LIBRARY_PATH}"
+
+# verify that this libvips has no openslide
+RUN ! python3 -c "import pyvips; pyvips.Image.openslideload(('CMU-1-Small-Region.svs'))"
+
+# ok, so to recap,
+# there are two libvips are installed and which one pyvips connects to
+# is chosen when "import pyvips" is run.
+# at this point in this dockerfile,
+# ld_library_path is set so that no-openslide version is run
+# but if you do LD_LIBRARY_PATH="${LD_LIBRARY_PATH_ORIG}" python a.py
+# or likewise using docker ENV command or os.environ in python before
+# importing, this will remove the no-openslide libvips from path.
 
 run openssl version -a
 


### PR DESCRIPTION
We'd like to have libvips without openslide. We use libvips for converting openslide-incompatible filetypes to tif so that we may view them with openslide, but having libvips from apt with openslide makes it already try to open them with openslide, so the benefit of this is small to nothing. By building it without openslide, we force imagemagick.

But this should be a second copy of libvips in our container in line with what tpan suggested - he might use libvips to process openslide output.

This change also allows us to rename a dicom file to png or jpeg and see it. This won't be the final dicom support, this rather uses conversion, but this will be used whenever a non-wsi dicom file is imported. I'm integrating this first because this is easier to handle than a separate openslide docker

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->

## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->

## Testing
Tested and convinced that this does work to convert dicoms. I also added some tests in the docker container for maintainability.

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
