### PR TITLE
Cache pip result: Faster building after code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,12 +69,11 @@ ENV FLASK_ENV development
 
 RUN mkdir -p /images/uploading
 
-COPY ./ ./
-
-RUN cp test_imgs/* /images/
-
+COPY requirements.txt .
 RUN pip3 install -r requirements.txt --break-system-packages
 
+COPY ./ ./
+RUN cp test_imgs/* /images/
 
 EXPOSE 4000
 EXPOSE 4001


### PR DESCRIPTION
This makes rebuilding almost instant.

Note: as many answers say on StackOverflow, COPY will overwrite and won't produce any warnings so it's not a problem that we copy requirements.txt twice