### PR TITLE
Restore correct workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,6 @@ RUN meson test -C build
 RUN meson install -C build
 
 RUN pip install pyvips --break-system-packages
-RUN pip install flask --break-system-packages
-RUN pip install gunicorn --break-system-packages
-RUN pip install greenlet --break-system-packages
-RUN pip install gunicorn[eventlet] --break-system-packages
 
 # verify pyvips can call libvips
 RUN python3 -c "import pyvips"
@@ -62,6 +58,13 @@ RUN ! python3 -c "import pyvips; pyvips.Image.openslideload(('CMU-1-Small-Region
 # but if you do LD_LIBRARY_PATH="${LD_LIBRARY_PATH_ORIG}" python a.py
 # or likewise using docker ENV command or os.environ in python before
 # importing, this will remove the no-openslide libvips from path.
+
+WORKDIR /root/src/
+
+RUN pip install flask --break-system-packages
+RUN pip install gunicorn --break-system-packages
+RUN pip install greenlet --break-system-packages
+RUN pip install gunicorn[eventlet] --break-system-package
 
 run openssl version -a
 


### PR DESCRIPTION
I changed workdir to libvips but forgot to restore it. I noticed this when I saw a crash log in it, which was confusing because it was SlideLoader that I ran, not libvips. So, after changing workdir to libvips, restore it. Meanwhile I change the order so that it's now clearer which dependencies belong to our server. I expect that my later pull requests bringing BioFormats won't modify this Dockerfile so it'll help reviewing that I do this change separately.