### PR TITLE
Reuse code for metadata

### DIFF
--- a/NCISlideUtil.py
+++ b/NCISlideUtil.py
@@ -72,7 +72,7 @@ def openslidedata(metadata):
     slide = openslide.OpenSlide(metadata['location'])
     slideData = slide.properties
     metadata['mpp-x'] = slideData.get(openslide.PROPERTY_NAME_MPP_X, None)
-    metadata['mpp-x'] = slideData.get(openslide.PROPERTY_NAME_MPP_Y, None)
+    metadata['mpp-y'] = slideData.get(openslide.PROPERTY_NAME_MPP_Y, None)
     metadata['mpp'] = metadata['mpp-x'] or metadata['mpp-x'] or None
     metadata['height'] = slideData.get(
         openslide.PROPERTY_NAME_BOUNDS_HEIGHT, None)

--- a/OmniLoad.py
+++ b/OmniLoad.py
@@ -8,6 +8,7 @@ import argparse # to read arguments
 import json # for json in and out
 import requests # for api and pathdb in and out
 import hashlib
+import dev_utils
 
 # for large csv fields, especially segmentations
 csv.field_size_limit(sys.maxsize)
@@ -51,21 +52,10 @@ def file_md5(fileName):
 def openslidedata(manifest):
     for img in manifest:
         img['location'] = img.get("path", "") or img.get("location", "") or img.get("filename", "") or img.get("file", "")
-        slide = openslide.OpenSlide(img['location'])
-        slideData = slide.properties
-        img['mpp-x'] = slideData.get(openslide.PROPERTY_NAME_MPP_X, None)
-        img['mpp-y'] = slideData.get(openslide.PROPERTY_NAME_MPP_Y, None)
-        img['mpp'] = img['mpp-x'] or img['mpp-y']
-        img['height'] = slideData.get(openslide.PROPERTY_NAME_BOUNDS_HEIGHT, None) or slideData.get(
-            "openslide.level[0].height", None)
-        img['width'] = slideData.get(openslide.PROPERTY_NAME_BOUNDS_WIDTH, None) or slideData.get(
-            "openslide.level[0].width", None)
-        img['vendor'] = slideData.get(openslide.PROPERTY_NAME_VENDOR, None)
-        img['level_count'] = int(slideData.get('level_count', 1))
-        img['objective'] = float(slideData.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER, 0) or
-                                      slideData.get("aperio.AppMag", -1.0))
-        img['md5sum'] = file_md5(img['location'])
-        img['comment'] = slideData.get(openslide.PROPERTY_NAME_COMMENT, None)
+        metadata = dev_utils.getMetadata(img['location'], False, True)
+        for k, v in metadata:
+          if k not in img:
+            img[k] = v
         # required values which are often unused
         img['study'] = img.get('study', "")
         img['specimen'] = img.get('specimen', "")

--- a/OmniLoad.py
+++ b/OmniLoad.py
@@ -53,7 +53,7 @@ def openslidedata(manifest):
     for img in manifest:
         img['location'] = img.get("path", "") or img.get("location", "") or img.get("filename", "") or img.get("file", "")
         metadata = dev_utils.getMetadata(img['location'], False, True)
-        for k, v in metadata:
+        for k, v in metadata.items():
           if k not in img:
             img[k] = v
         # required values which are often unused

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -203,7 +203,7 @@ def testRoute():
 @app.route("/data/one/<filepath>", methods=['GET'])
 def singleSlide(filepath):
     extended = request.args.get('extended')
-    res = dev_utils.getMetadata(join(app.config['UPLOAD_FOLDER'], filepath), extended)
+    res = dev_utils.getMetadata(join(app.config['UPLOAD_FOLDER'], filepath), extended, False)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)
     else:
@@ -226,7 +226,7 @@ def multiSlide(filepathlist):
     extended = request.args.get('extended')
     filenames = json.loads(filepathlist)
     paths = [join(app.config['UPLOAD_FOLDER'], filename) for filename in filenames]
-    res = dev_utils.getMetadataList(paths, extended)
+    res = dev_utils.getMetadataList(paths, extended, False)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)
     else:

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -6,8 +6,7 @@ import shutil
 import string
 import sys
 import pyvips
-from os import listdir
-from os.path import isfile, join
+import os
 from spritemaker import createSpritesheet
 from PIL import Image
 import urllib
@@ -203,7 +202,7 @@ def testRoute():
 @app.route("/data/one/<filepath>", methods=['GET'])
 def singleSlide(filepath):
     extended = request.args.get('extended')
-    res = dev_utils.getMetadata(join(app.config['UPLOAD_FOLDER'], filepath), extended, False)
+    res = dev_utils.getMetadata(os.path.join(app.config['UPLOAD_FOLDER'], filepath), extended, False)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)
     else:
@@ -225,7 +224,7 @@ def singleThumb(filepath):
 def multiSlide(filepathlist):
     extended = request.args.get('extended')
     filenames = json.loads(filepathlist)
-    paths = [join(app.config['UPLOAD_FOLDER'], filename) for filename in filenames]
+    paths = [os.path.join(app.config['UPLOAD_FOLDER'], filename) for filename in filenames]
     res = dev_utils.getMetadataList(paths, extended, False)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)

--- a/SlideServer.py
+++ b/SlideServer.py
@@ -203,7 +203,7 @@ def testRoute():
 @app.route("/data/one/<filepath>", methods=['GET'])
 def singleSlide(filepath):
     extended = request.args.get('extended')
-    res = dev_utils.getMetadata(filepath, app.config['UPLOAD_FOLDER'], extended)
+    res = dev_utils.getMetadata(join(app.config['UPLOAD_FOLDER'], filepath), extended)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)
     else:
@@ -223,8 +223,10 @@ def singleThumb(filepath):
 
 @app.route("/data/many/<filepathlist>", methods=['GET'])
 def multiSlide(filepathlist):
-    request.args.get('extended')
-    res = dev_utils.getMetadataList(json.loads(filepathlist), app.config['UPLOAD_FOLDER'], extended)
+    extended = request.args.get('extended')
+    filenames = json.loads(filepathlist)
+    paths = [join(app.config['UPLOAD_FOLDER'], filename) for filename in filenames]
+    res = dev_utils.getMetadataList(paths, extended)
     if (hasattr(res, 'error')):
         return flask.Response(json.dumps(res), status=500)
     else:

--- a/SlideUtil.py
+++ b/SlideUtil.py
@@ -35,7 +35,7 @@ def gen_thumbnail(filename, slide, size, imgtype="png"):
 
 def openslidedata(metadata):
     metadata_retrieved = getMetadata(metadata['location'], False, True)
-    for k, v in metadata_retrieved:
+    for k, v in metadata_retrieved.items():
         if k not in metadata:
             metadata[k] = v
     metadata['timestamp'] = time.time()

--- a/SlideUtil.py
+++ b/SlideUtil.py
@@ -5,7 +5,7 @@ from multiprocessing.pool import ThreadPool
 
 import openslide
 
-from dev_utils import file_md5
+from dev_utils import getMetadata
 from dev_utils import postslide
 from dev_utils import post_url
 
@@ -34,22 +34,14 @@ def gen_thumbnail(filename, slide, size, imgtype="png"):
 
 
 def openslidedata(metadata):
-    slide = openslide.OpenSlide(metadata['location'])
-    slideData = slide.properties
-    metadata['mpp-x'] = slideData.get(openslide.PROPERTY_NAME_MPP_X, None)
-    metadata['mpp-x'] = slideData.get(openslide.PROPERTY_NAME_MPP_Y, None)
-    metadata['mpp'] = metadata['mpp-x'] or metadata['mpp-x'] or None
-    # metadata['height'] = slideData.get("openslide.level[0].height", None)
-    # metadata['width'] = slideData.get("openslide.level[0].width", None)
-    metadata['height'] = slideData.get(openslide.PROPERTY_NAME_BOUNDS_HEIGHT, None)
-    metadata['width'] = slideData.get(openslide.PROPERTY_NAME_BOUNDS_WIDTH, None)
-    metadata['vendor'] = slideData.get(openslide.PROPERTY_NAME_VENDOR, None)
-    metadata['level_count'] = int(slideData.get('level_count', 1))
-    metadata['objective'] = float(slideData.get("aperio.AppMag", 0.0))
-    metadata['md5sum'] = file_md5(metadata['location'])
+    metadata_retrieved = getMetadata(metadata['location'], False, True)
+    for k, v in metadata_retrieved:
+        if k not in metadata:
+            metadata[k] = v
     metadata['timestamp'] = time.time()
     thumbnail_size = config.get('thumbnail_size', None)
     if thumbnail_size:
+        slide = openslide.OpenSlide(metadata['location'])
         gen_thumbnail(metadata['location'], slide, thumbnail_size)
     return metadata
 

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -10,10 +10,12 @@ post_url = "http://ca-back:4010/data/Slide/post"
 
 
 # given a path, get metadata
-def getMetadata(filepath, extended):
+def getMetadata(filepath, extended, raise_exception):
     # TODO consider restricting filepath
     metadata = {}
     if not os.path.isfile(filepath):
+        if raise_exception:
+            raise ValueError("No such file")
         msg = {"error": "No such file"}
         print(msg)
         return msg
@@ -21,6 +23,8 @@ def getMetadata(filepath, extended):
     try:
         slide = openslide.OpenSlide(filepath)
     except BaseException as e:
+        if raise_exception:
+            raise e
         msg = {"type": "Openslide", "error": str(e)}
         print(msg)
         return msg
@@ -59,10 +63,10 @@ def postslide(img, url, token=''):
 
 
 # given a list of path, get metadata for each
-def getMetadataList(filenames, extended):
+def getMetadataList(filenames, extended, raise_exception):
     allData = []
     for filename in filenames:
-        allData.append(getMetadata(filename, extended))
+        allData.append(getMetadata(filename, extended, raise_exception))
     return allData
 
 

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -10,10 +10,9 @@ post_url = "http://ca-back:4010/data/Slide/post"
 
 
 # given a path, get metadata
-def getMetadata(filename, upload_folder, extended):
+def getMetadata(filepath, extended):
     # TODO consider restricting filepath
     metadata = {}
-    filepath = os.path.join(upload_folder, filename)
     if not os.path.isfile(filepath):
         msg = {"error": "No such file"}
         print(msg)
@@ -60,10 +59,10 @@ def postslide(img, url, token=''):
 
 
 # given a list of path, get metadata for each
-def getMetadataList(filenames, upload_folder, extended):
+def getMetadataList(filenames, extended):
     allData = []
     for filename in filenames:
-        allData.append(getMetadata(filename, upload_folder, extended))
+        allData.append(getMetadata(filename, extended))
     return allData
 
 


### PR DESCRIPTION
## Summary
There were four copies of OpenSlide metadata code which I need to refactor for BioFormats. Now there's only two but not one because I'm keeping NCISlideUtil untouched.

## Testing

Visited `http://127.0.0.1:4010/loader/data/one/fileinimagesfolder.tif`, `http://127.0.0.1:4010/loader/data/many/[%22fileinimagesfolder%22]`. Isolated from Omniload.py, ran the modified code:

```
#import OmniLoad

import dev_utils
# get fields openslide expects
def openslidedata(manifest):
    for img in manifest:
        img['location'] = img.get("path", "") or img.get("location", "") or img.get("filename", "") or img.get("file", "")
        metadata = dev_utils.getMetadata(img['location'], False, True)
        print(metadata)
        for k, v in metadata.items():
          if k not in img:
            img[k] = v
        # required values which are often unused
        img['study'] = img.get('study', "")
        img['specimen'] = img.get('specimen', "")
    return manifest

print(openslidedata([{"path": "/tiff/file.tiff"}]))
```

## Questions

I hope it's OK to leave NCISlideUtil? That accesses some metadata I couldn't find documentation for so I won't be able to find BioFormats equivalents.