### PR TITLE
small deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN pip install gunicorn[eventlet] --break-system-package
 
 run openssl version -a
 
-ENV FLASK_ENV development
+ENV FLASK_DEBUG True
 
 RUN mkdir -p /images/uploading
 


### PR DESCRIPTION
> 'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.

docs https://flask.palletsprojects.com/en/2.3.x/config/#DEBUG