### PR TITLE
BioFormats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# BFBridge - should always stay in a separate repo but copied manually or by Docker
+BFBridge/

--- a/BioFormatsReader.py
+++ b/BioFormatsReader.py
@@ -1,0 +1,110 @@
+import image_reader
+import dev_utils
+import ome_types
+from file_extensions import BIOFORMATS_EXTENSIONS
+import BFBridge.python as bfbridge
+
+
+jvm = bfbridge.BFBridgeVM()
+
+class BioFormatsReader(image_reader.ImageReader):
+    @staticmethod
+    def reader_name():
+        return "bioformats"
+
+    @staticmethod
+    def extensions_set():
+        return BIOFORMATS_EXTENSIONS
+
+    def __init__(self, imagepath):
+        if not hasattr(dev_utils.keep_alive_for_thread, "bfthread"):
+            dev_utils.keep_alive_for_thread.bfthread = bfbridge.BFBridgeThread(jvm)
+
+        # Conventionally internal attributes start with underscore.
+        # When using them without underscore, there's the risk that
+        # a property has the same name as a/the getter, which breaks
+        # the abstract class. Hence all internal attributes start with underscore.
+        self._bfreader = bfbridge.BFBridgeInstance(dev_utils.keep_alive_for_thread.bfthread)
+        if self._bfreader is None:
+            raise RuntimeError("cannot make bioformats instance")
+        self._image_path = imagepath
+        code = self._bfreader.open(imagepath)
+        if code < 0:
+            raise IOError("Could not open file " + imagepath + ": " + self._bfreader.get_error_string())
+        # Note: actually stores the format, not the vendor ("Hamamatsu NDPI" instead of "Hamamatsu")
+        self._vendor = self._bfreader.get_format()
+        self._level_count = self._bfreader.get_resolution_count()
+        self._dimensions = (self._bfreader.get_size_x(), self._bfreader.get_size_y())
+        self._level_dimensions = [self._dimensions]
+        for l in range(1, self._level_count):
+            self._bfreader.set_current_resolution(l)
+            self._level_dimensions.append( \
+                (self._bfreader.get_size_x(), self._bfreader.get_size_y()))
+
+    @property
+    def level_count(self):
+        return self._level_count
+
+    @property
+    def dimensions(self):
+        return self._dimensions
+
+    @property
+    def level_dimensions(self):
+        return self._level_dimensions
+
+    @property
+    def associated_images(self):
+        return None
+
+    def read_region(self, location, level, size):
+        self._bfreader.set_current_resolution(level)
+        return self._bfreader.open_bytes_pil_image(0, \
+            location[0], location[1], size[0], size[1])
+
+    def get_thumbnail(self, max_size):
+        return self._bfreader.open_thumb_bytes_pil_image(0, max_size[0], max_size[1])
+
+    def get_basic_metadata(self, extended):
+        metadata = {}
+
+        try:
+            ome_xml_raw = self._bfreader.dump_ome_xml_metadata()
+        except BaseException as e:
+            raise OverflowError("XML metadata too large for file considering the preallocated buffer length. " + str(e))
+        try:
+            ome_xml = ome_types.from_xml(ome_xml_raw)
+        except BaseException as e:
+            raise RuntimeError("get_basic_metadata: OME-XML parsing of metadata failed, error: " + \
+                str(e) + " when parsing: " + ome_xml_raw)
+
+        # https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html
+        # https://bio-formats.readthedocs.io/en/latest/metadata-summary.html
+
+        if extended:
+            return {"ome-xml": ome_xml_raw}
+
+        metadata['width'] = str(self._dimensions[0])
+        metadata['height'] = str(self._dimensions[1])
+        try:
+            metadata['mpp-x'] = str(ome_xml.images[0].pixels.physical_size_x)
+            metadata['mpp-y'] = str(ome_xml.images[0].pixels.physical_size_y)
+        except:
+            metadata['mpp-x'] = "0"
+            metadata['mpp-y'] = "0"
+        metadata['vendor'] = self._vendor
+        metadata['level_count'] = int(self._level_count)
+        try:
+            metadata['objective'] = ome_xml.instruments[0].objectives[0].nominal_magnification
+        except:
+            try:
+                metadata['objective'] = ome_xml.instruments[0].objectives[0].calibrated_magnification
+            except:
+                metadata['objective'] = -1.0
+
+        metadata['comment'] = ""
+        metadata['study'] = ""
+        metadata['specimen'] = ""
+        metadata['md5sum'] = dev_utils.file_md5(self._image_path)
+
+        return metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get -q update --fix-missing
 RUN apt-get -q install -y python3-pip openslide-tools python3-openslide vim openssl
 RUN apt-get -q install -y openssl libcurl4-openssl-dev libssl-dev
 
+### Install libvips
+
 # Tony has a future use case where we may adapt caMic to GIS visualization
 # install libvips-dev for pyvips. No need for libvips.
 RUN apt-get -q install -y libvips-dev
@@ -59,6 +61,13 @@ RUN ! python3 -c "import pyvips; pyvips.Image.openslideload(('CMU-1-Small-Region
 # or likewise using docker ENV command or os.environ in python before
 # importing, this will remove the no-openslide libvips from path.
 
+### Install BioFormats wrapper
+
+WORKDIR /root/src/BFBridge/python
+RUN python3 compile_bfbridge.py
+
+### Set up the server
+
 WORKDIR /root/src/
 
 RUN pip install flask --break-system-packages
@@ -83,7 +92,7 @@ EXPOSE 4001
 
 #debug/dev only
 # ENV FLASK_APP SlideServer.py
-# CMD python -m flask run --host=0.0.0.0 --port=4000
+# CMD python3 -m flask run --host=0.0.0.0 --port=4000
 
 # The Below BROKE the ability for users to upload images.
 # # non-root user

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # SlideLoader
 Tool for loading slides and getting slide metadata using openslide
 
+## Setting up
+
+When used outside of caMicroscope/Distro Docker, the [BFBridge](https://github.com/camicroscope/BFBridge) folder needs to copied to this repository manually. (Not only its contents, but making it a subfolder of this repository)
+
 ## Usage
 
 ### Upload

--- a/dev_utils.py
+++ b/dev_utils.py
@@ -3,10 +3,14 @@ import os
 import json
 import requests
 import image_reader
+import threading
 
 post_url = "http://ca-back:4010/data/Slide/post"
 
 
+
+# Keep BioFormats Java thread alive; to minimize reattaching thread
+keep_alive_for_thread = threading.local()
 
 # given a path, get metadata
 def getMetadata(filepath, extended, raise_exception):

--- a/image_reader.py
+++ b/image_reader.py
@@ -54,9 +54,10 @@ class ImageReader(metaclass=ABCMeta):
         pass
 
 from OpenSlideReader import OpenSlideReader
+from BioFormatsReader import BioFormatsReader
 
-# Decreasing order of importance
-readers = [OpenSlideReader]
+# Decreasing order of performance
+readers = [OpenSlideReader, BioFormatsReader]
 
 
 # Replaces the constructor of the abstract class

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 numpy
 Pillow
 cffi
-ome-xml
+ome-types
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ flask-cors
 requests
 numpy
 Pillow
+cffi
+ome-xml
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib


### PR DESCRIPTION
Ryan, could you please rebuild and update the Dockerhub image for https://github.com/camicroscope/image-decoders/tree/main please? These are the changes from the last time: https://github.com/camicroscope/image-decoders/compare/ab596801cc8b6c5f8e45aa239ca7310f7121356b...e24cce6b905f9d6316e760dd4a3806104d90b883

https://downloads.openmicroscopy.org/images/Olympus-FluoView/imagesc-71616/ is a good testfile for bioformats, I think our code works well.

One solution I couldn't solve (and I'm not sure if it's worth investing time in this, you decide) is that despite having tried two methods to change this, it continues to print at DEBUG level instead of warning level, so console output is helpful but takes space.