### PR TITLE
Change BioFormat console Log Level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN pip install gunicorn[eventlet]
 run openssl version -a
 
 ENV FLASK_ENV development
+ENV BFBRIDGE_LOGLEVEL=WARN
 
 RUN mkdir -p /images/uploading
 


### PR DESCRIPTION
Ryan this requires updating image-decoders which would be great, many thanks.

To test this, please upload a DICOM file through caMicroscope interface (not Orthanc) and there shouldn't be ~50 lines or more extra in the logs

to continue debugging, please change the value to DEBUG